### PR TITLE
chore: add .catalog/catalog-info.yaml

### DIFF
--- a/.catalog/catalog-info.yaml
+++ b/.catalog/catalog-info.yaml
@@ -1,0 +1,47 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: harbor-operator
+  title: Harbor Operator (v3)
+  description: harbor operator (v3)，用于管理 harbor 工具的生命周期。
+  annotations:
+    # github plugin
+    github.com/project-slug: alauda/harbor
+    # acp cicd plugin
+    acp.cpaas.io/ci-pipeline: devops/business-build/tools/harbor
+    acp.cpaas.io/instance: edge.alauda.cn
+
+    # harbor plugin
+    goharbor.io/repository-slug: devops/harbor-operator,devops/harbor-operator-bundle,devops/goharbor-harbor-portal,devops/goharbor-notary-server-photon,devops/goharbor-notary-signer-photon,devops/goharbor-harbor-registryctl,devops/goharbor-registry-photon,devops/goharbor-nginx-photon,devops/goharbor-harbor-jobservice,devops/goharbor-harbor-core,devops/goharbor-chartmuseum-photon,devops/goharbor-trivy-adapter-photon,devops/goharbor-harbor-exporter,devops/goharbor-trivy-offline-db
+    # sonarqube plugin
+    sonarqube.org/project-key: github.com-alauda-harbor
+    # 开源组件代码仓库地址，格式：${url}/${project}/${repo}
+    acp.cpaas.io/open-source-component-repo: https://github.com/goharbor/harbor
+    # 开源组件的版本信息，只适用于开源组件，自研组件默认不收集版本信息,格式 ${version}
+    acp.cpaas.io/open-source-component-version: main
+    # 开源组件的license信息,格式 ${license}
+    acp.cpaas.io/open-source-component-license: Apache-2.0
+    # 开源组件的license地址,格式 ${url}/${project}/${repo}/${license-path}
+    acp.cpaas.io/open-source-component-license_url: https://github.com/goharbor/harbor/blob/main/LICENSE
+    # backstage techdocs plugin
+    backstage.io/techdocs-ref: dir:.
+    acp.cpaas.io/owner: jtcheng@alauda.io
+
+    acp.cpaas.io/functional-attributes: plugin
+spec:
+  type: service
+  system: system:devops-tools
+  lifecycle: production
+  owner: devops
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: devops-tools
+  title: Devops Tools
+  tags:
+  - golang
+  - devops
+spec:
+  owner: devops
+  domain: devops


### PR DESCRIPTION
## Summary
- add .catalog/catalog-info.yaml for Backstage catalog registration
- keep the source-of-truth component metadata with the repository

## Testing
- yaml parse check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Harbor Operator service metadata into the internal service registry with links to documentation, CI/CD resources, repository information, and code quality monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->